### PR TITLE
apply fix for when pull_containers: False

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 docker_apps_env: '_default'
+docker_force_restart: False

--- a/tasks/docker_start.yml
+++ b/tasks/docker_start.yml
@@ -6,6 +6,16 @@
 - name: "{{ docker_app_num }}/{{ docker_apps_total}}: START CONTAINER: Get image version: {{ docker_app['name'] }}"
   include: get_image_ver.yml
 
+- name: "{{ docker_app_num }}/{{ docker_apps_total}}: START CONTAINER: Set app_status if pull is set to false: {{ docker_app['name'] }}"
+  set_fact:
+    app_status: "{
+        '{{ docker_image_with_ver }}': {
+          'changed': False
+         }
+      }"
+  when: ( app_status[docker_image_with_ver] is not defined )
+
+
 - name: "{{ docker_app_num }}/{{ docker_apps_total}} {{ docker_app['name'] }}: REMOVE CONTAINER"
   docker_container:
     name:   "{{ docker_app['name'] }}"


### PR DESCRIPTION
Specifically, this fixes a bug that would cause a line in the main docker task of docker_start to fail.  This is because the default jinja feature only goes "one" deep.  E.g. If b is not defined, this will not work:
`"{{ a[b][c] | default(foo) }}"`