### PR TITLE
Tests after network creation

### DIFF
--- a/tasks/docker_network.yml
+++ b/tasks/docker_network.yml
@@ -1,0 +1,7 @@
+---
+- name: Create a network
+  docker_network:
+    name: "{{ item }}"
+    connected: "{{ item.containers }}"
+  with_items: docker_networks
+  when: docker_networks is defined

--- a/tasks/docker_network.yml
+++ b/tasks/docker_network.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create a network
   docker_network:
-    name: "{{ item }}"
+    name: "{{ item.name }}"
     connected: "{{ item.containers }}"
-  with_items: docker_networks
+  loop: "{{ docker_networks }}"
   when: docker_networks is defined

--- a/tasks/docker_start.yml
+++ b/tasks/docker_start.yml
@@ -23,7 +23,7 @@
   when: ( docker_app['docker']['state'] == 'absent' )
 
 
-- name: "{{ docker_app_num }}/{{ docker_apps_total}} {{ docker_app['name'] }}: START CONTAINER AND TEST"
+- name: "{{ docker_app_num }}/{{ docker_apps_total}} {{ docker_app['name'] }}: START CONTAINER"
   block:
   #--------------------------
   # start block
@@ -48,30 +48,10 @@
         restart:        "{{ app_status[docker_image_with_ver]['changed'] | default(docker_force_restart) }}"
         pull:           false # always pull from the docker_pull.yml, NOT here
 
-    - name: "{{ docker_app_num }}/{{ docker_apps_total}} {{ docker_app['name'] }}: GET CONTAINER STATUS"
-      shell: |
-        docker inspect --format \{\{.State.Status\}\} {{ docker_app['name'] }}
-      register: container_status
-      changed_when: False
-
-    ## Possibilities as of ansible 2.3.1
-    ## docker states: [ absent, present, stopped, started ]
-    ## possible stati: [ created|restarting|running|removing|paused|exited|dead ]
-
-    - name: Pause before testing container status
-      pause:
-        seconds: 4
-
-    - name: "{{ docker_app_num }}/{{ docker_apps_total}} {{ docker_app['name'] }}: TEST CONTAINER STATUS"
-      assert:
-        that: "container_status.stdout in ({% if docker_app['docker']['state'] is defined %}{% if docker_app['docker']['state'] == 'started' %}'running'{% elif docker_app['docker']['state'] == 'stopped'%}'exited,paused,created'{% elif docker_app['docker']['state'] == 'present'%}'created'{% endif %}{% else %}'running'{% endif %})"
-        msg: "container status- [ {{ container_status.stdout}} ] != desired state: [ {{ docker_app['docker']['state'] | default('started') }} ]"
-
-
   #--------------------------
   # end block
   #--------------------------
-  when: 
+  when:
     ( docker_image_with_ver != 'disabled:disabled' )
     and
     ( docker_app['docker']['state'] != 'absent' )
@@ -80,4 +60,3 @@
   debug:
     msg: "{{ docker_app['name'] }} is disabled in the env for this node"
   when: ( docker_image_with_ver == 'disabled:disabled' )
-

--- a/tasks/docker_test.yml
+++ b/tasks/docker_test.yml
@@ -1,0 +1,30 @@
+---
+- name: "{{ docker_app_num }}/{{ docker_apps_total}} {{ docker_app['name'] }}: TEST CONTAINER"
+  block:
+  #--------------------------
+  # test block
+  #--------------------------
+    ## Possibilities as of ansible 2.3.1
+    ## docker states: [ absent, present, stopped, started ]
+    ## possible stati: [ created|restarting|running|removing|paused|exited|dead ]
+
+    - name: "{{ docker_app_num }}/{{ docker_apps_total}} {{ docker_app['name'] }}: GET CONTAINER STATUS"
+      shell: |
+        docker inspect --format \{\{.State.Status\}\} {{ docker_app['name'] }}
+      register: container_status
+      changed_when: False
+
+
+    - name: "{{ docker_app_num }}/{{ docker_apps_total}} {{ docker_app['name'] }}: TEST CONTAINER STATUS"
+      assert:
+        that: "container_status.stdout in ({% if docker_app['docker']['state'] is defined %}{% if docker_app['docker']['state'] == 'started' %}'running'{% elif docker_app['docker']['state'] == 'stopped'%}'exited,paused,created'{% elif docker_app['docker']['state'] == 'present'%}'created'{% endif %}{% else %}'running'{% endif %})"
+        msg: "container status- [ {{ container_status.stdout}} ] != desired state: [ {{ docker_app['docker']['state'] | default('started') }} ]"
+
+
+  #--------------------------
+  # end block
+  #--------------------------
+  when:
+    ( docker_image_with_ver != 'disabled:disabled' )
+    and
+    ( docker_app['docker']['state'] != 'absent' )

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,13 +7,13 @@
 - name: Debug docker_apps
   debug:
     var: docker_apps
-  tags: [docker_pull,docker_start]
+
 
 - set_fact:
     app_status: {}
   tags: [docker_pull,docker_start]
 
-- block: 
+- block:
   - set_fact:
       docker_apps_total: "{{ docker_apps | length }}"
     tags: docker_pull
@@ -35,3 +35,5 @@
     tags: docker_start
 
   when: docker_apps is defined
+
+- include: docker_network.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Debug docker_apps
   debug:
     var: docker_apps
-
+  tags: [docker_pull,docker_start] 
 
 - set_fact:
     app_status: {}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Debug docker_apps
   debug:
     var: docker_apps
-  tags: [docker_pull,docker_start] 
+  tags: [docker_pull,docker_start]
 
 - set_fact:
     app_status: {}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,6 +34,15 @@
     with_items: "{{ docker_apps }}"
     tags: docker_start
 
-  when: docker_apps is defined
+  - include: docker_network.yml
+    tags: docker_network
 
-- include: docker_network.yml
+  - name: Pause before testing container status
+    pause:
+      seconds: 4
+
+  - include: docker_test.yml
+    with_items: "{{ docker_apps }}"
+    tags: docker_test
+
+  when: docker_apps is defined


### PR DESCRIPTION
Tests that depend on containers being part of a specific network will fail if the networks are created after the said tests. 
This PR moves the the tests into it's own ".yml" and it's run after the networking task. 