### PR TITLE
Add docker_network options

### DIFF
--- a/tasks/docker_network.yml
+++ b/tasks/docker_network.yml
@@ -2,6 +2,9 @@
 - name: Create a network
   docker_network:
     name: "{{ item.name }}"
+    driver: "{{ item.driver | default('bridge') }}"
+    driver_options: "{{ item.driver_options | default('omit') }}"
+    internal: "{{ item.internal | deffault('no') }}"
     connected: "{{ item.containers }}"
   loop: "{{ docker_networks }}"
   when: docker_networks is defined

--- a/tasks/docker_network.yml
+++ b/tasks/docker_network.yml
@@ -4,7 +4,8 @@
     name: "{{ item.name }}"
     driver: "{{ item.driver | default('bridge') }}"
     driver_options: "{{ item.driver_options | default('omit') }}"
-    internal: "{{ item.internal | deffault('no') }}"
+    internal: "{{ item.internal | default('no') }}"
     connected: "{{ item.containers }}"
+    ipam_config: "{{item.ipam_config | default('omit') }}"
   loop: "{{ docker_networks }}"
   when: docker_networks is defined

--- a/tasks/docker_network.yml
+++ b/tasks/docker_network.yml
@@ -3,9 +3,9 @@
   docker_network:
     name: "{{ item.name }}"
     driver: "{{ item.driver | default('bridge') }}"
-    driver_options: "{{ item.driver_options | default('omit') }}"
+    driver_options: "{{ item.driver_options | default(omit) }}"
     internal: "{{ item.internal | default('no') }}"
-    connected: "{{ item.containers }}"
-    ipam_config: "{{item.ipam_config | default('omit') }}"
+    connected: "{{ item.containers  | default (omit) }}"
+    ipam_config: "{{item.ipam_config | default(omit) }}"
   loop: "{{ docker_networks }}"
   when: docker_networks is defined

--- a/tasks/docker_start.yml
+++ b/tasks/docker_start.yml
@@ -44,6 +44,7 @@
         dns_servers:    "{{ docker_app['docker']['dns_servers']    | default(omit) }}"
         user:           "{{ docker_app['docker']['user']           | default(omit) }}"
         networks:        "{{ docker_app['docker']['networks']      | default(omit) }}"
+        networks_cli_compatible:        "{{ docker_app['docker']['networks_cli']      | default(omit) }}"
         restart_policy: "{{ docker_app['docker']['restart_policy'] | default('always') }}"
         env:            "{{ docker_app['docker']['env']            | default(docker_app['docker']['environment']) | default({}) }}"
         restart:        "{{ app_status[docker_image_with_ver]['changed'] | default(docker_force_restart) }}"

--- a/tasks/docker_start.yml
+++ b/tasks/docker_start.yml
@@ -43,6 +43,7 @@
         log_options:    "{{ docker_app['docker']['log_options']    | default(omit) }}"
         dns_servers:    "{{ docker_app['docker']['dns_servers']    | default(omit) }}"
         user:           "{{ docker_app['docker']['user']           | default(omit) }}"
+        networks:        "{{ docker_app['docker']['networks']      | default(omit) }}"
         restart_policy: "{{ docker_app['docker']['restart_policy'] | default('always') }}"
         env:            "{{ docker_app['docker']['env']            | default(docker_app['docker']['environment']) | default({}) }}"
         restart:        "{{ app_status[docker_image_with_ver]['changed'] | default(docker_force_restart) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,12 +30,12 @@
       docker_app_num: 0
     tags: docker_start
 
+  - include: docker_network.yml
+    tags: docker_network
+
   - include: docker_start.yml
     with_items: "{{ docker_apps }}"
     tags: docker_start
-
-  - include: docker_network.yml
-    tags: docker_network
 
   - name: Pause before testing container status
     pause:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,11 +31,16 @@
     tags: docker_start
 
   - include: docker_network.yml
+    when: docker_networks.containers is not defined
     tags: docker_network
 
   - include: docker_start.yml
     with_items: "{{ docker_apps }}"
     tags: docker_start
+
+  - include: docker_network.yml
+    when: docker_networks.containers is defined
+    tags: docker_network
 
   - name: Pause before testing container status
     pause:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,7 @@
     tags: docker_start
 
   - include: docker_network.yml
-    when: docker_networks.containers is not defined
+    when: docker_networks | selectattr('containers', 'undefined')
     tags: docker_network
 
   - include: docker_start.yml
@@ -39,7 +39,7 @@
     tags: docker_start
 
   - include: docker_network.yml
-    when: docker_networks.containers is defined
+    when: docker_networks | selectattr('containers', 'defined')
     tags: docker_network
 
   - name: Pause before testing container status

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,9 @@
     tags: docker_start
 
   - include: docker_network.yml
-    when: docker_networks | selectattr('containers', 'undefined')
+    when:
+      - docker_networks is defined
+      - docker_networks.0.containers is undefined
     tags: docker_network
 
   - include: docker_start.yml
@@ -39,7 +41,9 @@
     tags: docker_start
 
   - include: docker_network.yml
-    when: docker_networks | selectattr('containers', 'defined')
+    when:
+      - docker_networks is defined
+      - docker_networks.0.containers is defined
     tags: docker_network
 
   - name: Pause before testing container status


### PR DESCRIPTION
This pr allows docker_networks to be specified without containers, but also has backwards compatibility.

Also adds advanced network options.